### PR TITLE
Update _woocommerce.md

### DIFF
--- a/docs/wiki/_woocommerce.md
+++ b/docs/wiki/_woocommerce.md
@@ -17,7 +17,7 @@ $context['sidebar'] = Timber::get_widgets('shop-sidebar');
 if (is_singular('product')) {
 
     $context['post']    = Timber::get_post();
-    $product            = get_product( $context['post']->ID );
+    $product            = wc_get_product( $context['post']->ID );
     $context['product'] = $product;
 
     Timber::render('views/woo/single-product.twig', $context);
@@ -162,7 +162,7 @@ For some reason products in the loop don't get the right context by default. Thi
 function timber_set_product( $post ) {
     global $product;
     if ( is_woocommerce() ) {
-        $product = get_product($post->ID);
+        $product = wc_get_product($post->ID);
     }
 }
 ```


### PR DESCRIPTION
`get_product()` is deprecated. Replace mention of function with `wc_get_product()`.

**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->


#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->


#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->


#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
